### PR TITLE
Fixed OGG files ending halfway

### DIFF
--- a/SAAT.API/AudioManager.cs
+++ b/SAAT.API/AudioManager.cs
@@ -278,14 +278,15 @@ namespace SAAT.API
             using var reader = new VorbisReader(stream, true);
 
             // At the moment, we're loading everything in. If the number of samples is greater than int.MaxValue, bail.
-            if (reader.TotalSamples > int.MaxValue)
+            if (reader.TotalSamples * reader.Channels > int.MaxValue)
             {
                 throw new Exception("TotalSample overflow");
             }
 
-            int totalSamples = (int)reader.TotalSamples;
+            // The samples to read has to be adjusted for mono/stereo.
+            int totalSamples = (int)reader.TotalSamples * reader.Channels;
             int sampleRate = reader.SampleRate;
-            
+
             // SoundEffect.SampleSizeInBytes has a fault within it. In conjunction with a small amount of percision loss,
             // any decimal points are dropped instead of rounded up. For example: It will calculate the buffer size to be
             // 2141.999984, returning 2141. This should be 2142, as it violates block alignment below.


### PR DESCRIPTION
OGG files ended prematurely in-game due to VorbisReader reading samples in accordance with the amount of channels the audio has. SAAT previously failed to adjust the sample count to read based on mono/stereo.

This leads to a bug where audio ended exactly halfway through (for stereo) and then the game thinks that audio is still playing despite the fact that it isn't. I have tested the fix and can confirm that it works.